### PR TITLE
תיקון שגיאת תחביר בקובץ שיעורים

### DIFF
--- a/lessons_part3.py
+++ b/lessons_part3.py
@@ -270,16 +270,16 @@ print_info(name="אמיר", age=25, city="תל אביב")</code>
 
 💪 <b>docstring - תיעוד פונקציה:</b>
 <code>def calculate_area(width, height):
-    """
-    מחשב שטח מלבן.
-    
-    Args:
-        width: רוחב המלבן
-        height: גובה המלבן
-    
-    Returns:
-        שטח המלבן
-    """
+      '''
+      מחשב שטח מלבן.
+      
+      Args:
+          width: רוחב המלבן
+          height: גובה המלבן
+      
+      Returns:
+          שטח המלבן
+      '''
     return width * height
 
 # גישה לתיעוד:


### PR DESCRIPTION
Fix `SyntaxError` in `lessons_part3.py` by changing docstring delimiters from `"""` to `'''`.

The `SyntaxError` occurred because a docstring using `"""` was prematurely terminating a larger `"""` string used for lesson content, leading to invalid syntax.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0561314-69bc-4dfe-b579-7c9758f4319f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e0561314-69bc-4dfe-b579-7c9758f4319f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

