### PR TITLE
Fix telegram escape_html import error

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6,13 +6,26 @@ Python Learning Bot - בוט טלגרם ללימוד Python
 import logging
 import sys
 from telegram import Update
-from telegram.helpers import escape_html
 from telegram.ext import (
     Application,
     CommandHandler,
     CallbackQueryHandler,
     ContextTypes
 )
+
+try:
+    from telegram.helpers import escape_html  # type: ignore
+except ImportError:
+    from html import escape as html_escape
+
+    def escape_html(value: str | None) -> str:
+        """
+        Fallback escape function for environments where python-telegram-bot
+        no longer exports escape_html (e.g. PTB 21+).
+        """
+        if not value:
+            return ""
+        return html_escape(value, quote=False)
 
 
 def _ensure_ptb_py313_compatibility():


### PR DESCRIPTION
Add a compatibility shim for `escape_html` to resolve `ImportError` with `python-telegram-bot` versions that no longer export it.

---
<a href="https://cursor.com/background-agent?bcId=bc-0147331c-00b1-4274-8d91-2a4dec6e3f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0147331c-00b1-4274-8d91-2a4dec6e3f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

